### PR TITLE
Add Google Test integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,16 +107,20 @@ target_link_libraries(file_parser PRIVATE dummy)
 # Enable testing framework
 enable_testing()
 
+# Google Test
+find_package(GTest CONFIG REQUIRED)
+
 # Create test executable
 add_executable(dummy_test
     tests/dummy_test.cpp
 )
 
-# Link test executable with the library
-target_link_libraries(dummy_test PRIVATE dummy)
+# Link test executable with Google Test and the library
+target_link_libraries(dummy_test PRIVATE dummy GTest::gtest_main)
 
 # Register the test with CTest
-add_test(NAME DummyTest COMMAND dummy_test)
+include(GoogleTest)
+gtest_discover_tests(dummy_test)
 
 # ============================================================================
 # CODE QUALITY CUSTOM TARGETS

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmak
 # Build the project
 cmake --build build
 
-# Run tests
+# Run tests (uses Google Test)
 ctest --test-dir build
 ```
 
@@ -103,12 +103,12 @@ ctest --test-dir build
 After building, test that everything works:
 
 ```bash
-# Run tests
-./dev.sh test
+# Run tests (Google Test)
+./dev.sh test run
 
 # Or manually:
 cd build
-ctest
+ctest  # runs Google Test suite
 
 # Run the main executable
 ./dev.sh run

--- a/tests/dummy_test.cpp
+++ b/tests/dummy_test.cpp
@@ -1,12 +1,12 @@
 #include "compression.h"
 #include "dummy.h"
-#include <cassert>
-#include <iostream>
+#include <gtest/gtest.h>
 
-int main() {
-    assert(addNumbers(2, 3) == 5);
-    std::string version = getZlibVersion();
-    assert(!version.empty());
-    std::cout << "zlib version: " << version << std::endl;
-    return 0;
+TEST(DummyLibrary, AddNumbers) {
+    EXPECT_EQ(addNumbers(2, 3), 5);
 }
+
+TEST(DummyLibrary, ZlibVersionNotEmpty) {
+    EXPECT_FALSE(getZlibVersion().empty());
+}
+

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
     {
       "name": "zlib",
       "version>=": "1.3.1"
-    }
+    },
+    "gtest"
   ]
 }


### PR DESCRIPTION
## Summary
- use gtest through vcpkg
- update CMake to use Google Test
- convert dummy test to gtest
- document how to run tests

## Testing
- `./dev.sh build debug`
- `./dev.sh test run`


------
https://chatgpt.com/codex/tasks/task_e_686e04784708832fa033d8d556e68d5e